### PR TITLE
Modernize site design with Awwwards-inspired refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,29 @@
     ]
   }
   </script>
+  <script>
+    (function () {
+      var MODE_KEY = 'portfolio-theme-mode';
+      var MANUAL_KEY = 'portfolio-theme-manual';
+      var hour = new Date().getHours();
+      var isDay = hour >= 7 && hour < 19;
+      var mode = localStorage.getItem(MODE_KEY);
+      var manual = localStorage.getItem(MANUAL_KEY);
+      var theme;
+
+      if (mode === 'manual' && (manual === 'light-theme' || manual === 'dark-theme')) {
+        theme = manual;
+      } else {
+        theme = isDay ? 'light-theme' : 'dark-theme';
+      }
+
+      document.documentElement.className = theme;
+      var meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) {
+        meta.setAttribute('content', theme === 'dark-theme' ? '#09090b' : '#f7f6f3');
+      }
+    })();
+  </script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#f7f6f3" />
+  <meta name="theme-color" content="#09090b" />
   <meta name="description"
     content="Operations dashboards and workflow automation for small businesses. See stock, reorders, and daily ops clearly. Book a workflow audit or explore the NovaFit example. Full-stack developer in Vancouver, BC." />
   <meta name="keywords"

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#f8fafc" />
+  <meta name="theme-color" content="#f7f6f3" />
   <meta name="description"
     content="Operations dashboards and workflow automation for small businesses. See stock, reorders, and daily ops clearly. Book a workflow audit or explore the NovaFit example. Full-stack developer in Vancouver, BC." />
   <meta name="keywords"
@@ -28,8 +28,9 @@
     content="Operations dashboards and workflow automation for small businesses. Book a workflow audit or explore the NovaFit example." />
   <meta name="twitter:creator" content="@GargiGingerly" />
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Syne:wght@500;600;700;800&display=swap" rel="stylesheet">
 
   <title>Gargi Thakur | Operations Dashboards & Workflow Automation for Small Businesses</title>
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -20,4 +20,8 @@
     <loc>https://gargithakur.com/contact</loc>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://gargithakur.com/privacy</loc>
+    <priority>0.4</priority>
+  </url>
 </urlset>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,38 +9,65 @@ import ServicesPage from './Pages/ServicesPage';
 import DemoPage from './Pages/DemoPage';
 import ContactPage from './Pages/ContactPage';
 import { Routes, Route } from 'react-router-dom';
-
-const THEME_STORAGE_KEY = 'portfolio-theme';
-
-function getInitialTheme() {
-  const saved = localStorage.getItem(THEME_STORAGE_KEY);
-  if (saved === 'light-theme' || saved === 'dark-theme') {
-    return saved;
-  }
-  return 'dark-theme';
-}
+import {
+  getInitialThemeState,
+  getThemeForTimeOfDay,
+  msUntilNextThemeChange,
+  persistThemeState,
+  resolveTheme,
+} from './utils/theme';
 
 function App() {
-  const [theme, setTheme] = useState(getInitialTheme);
-  const [checked, setChecked] = useState(() => getInitialTheme() === 'dark-theme');
+  const [themeState, setThemeState] = useState(getInitialThemeState);
+  const [scheduleTick, setScheduleTick] = useState(0);
   const [navOpen, setNavOpen] = useState(false);
+
+  const theme = resolveTheme(themeState.mode, themeState.manualTheme, scheduleTick);
+  const isDark = theme === 'dark-theme';
+  const isAuto = themeState.mode === 'auto';
 
   useEffect(() => {
     document.documentElement.className = theme;
-    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    persistThemeState(themeState.mode, themeState.manualTheme);
     document
       .querySelector('meta[name="theme-color"]')
-      ?.setAttribute('content', theme === 'dark-theme' ? '#09090b' : '#f7f6f3');
-  }, [theme]);
+      ?.setAttribute('content', isDark ? '#09090b' : '#f7f6f3');
+  }, [theme, themeState, isDark]);
+
+  useEffect(() => {
+    if (!isAuto) {
+      return undefined;
+    }
+
+    let timeoutId;
+
+    const scheduleNextSwitch = () => {
+      timeoutId = window.setTimeout(() => {
+        setScheduleTick((tick) => tick + 1);
+        scheduleNextSwitch();
+      }, msUntilNextThemeChange());
+    };
+
+    scheduleNextSwitch();
+
+    const intervalId = window.setInterval(() => {
+      setScheduleTick((tick) => tick + 1);
+    }, 60_000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.clearInterval(intervalId);
+    };
+  }, [isAuto]);
 
   const themeToggler = () => {
-    if (theme === 'light-theme') {
-      setTheme('dark-theme');
-      setChecked(true);
-    } else {
-      setTheme('light-theme');
-      setChecked(false);
-    }
+    const currentTheme = isAuto ? getThemeForTimeOfDay() : themeState.manualTheme;
+    const nextTheme = currentTheme === 'light-theme' ? 'dark-theme' : 'light-theme';
+
+    setThemeState({
+      mode: 'manual',
+      manualTheme: nextTheme,
+    });
   };
 
   return (
@@ -54,7 +81,8 @@ function App() {
         setNavOpen={setNavOpen}
         theme={theme}
         onThemeToggle={themeToggler}
-        themeChecked={checked}
+        themeChecked={isDark}
+        themePreference={isAuto ? 'auto' : themeState.manualTheme}
       />
       <MainContentStyled>
         <Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import AboutPage from './Pages/AboutPage';
 import ServicesPage from './Pages/ServicesPage';
 import DemoPage from './Pages/DemoPage';
 import ContactPage from './Pages/ContactPage';
+import PrivacyPage from './Pages/PrivacyPage';
 import { Routes, Route } from 'react-router-dom';
 import {
   getInitialThemeState,
@@ -91,6 +92,7 @@ function App() {
           <Route path="/services" element={<ServicesPage />} />
           <Route path="/demo" element={<DemoPage />} />
           <Route path="/contact" element={<ContactPage />} />
+          <Route path="/privacy" element={<PrivacyPage />} />
         </Routes>
       </MainContentStyled>
       <Footer />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from "react";
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import Header from "./Components/Header";
 import Footer from "./Components/Footer";
 import HomePage from "./Pages/HomePage";
@@ -31,6 +31,10 @@ function App() {
 
   return (
     <AppStyled>
+      <div className="ambient ambient-one" aria-hidden="true" />
+      <div className="ambient ambient-two" aria-hidden="true" />
+      <div className="ambient ambient-three" aria-hidden="true" />
+      <div className="grid-overlay" aria-hidden="true" />
       <Header
         navOpen={navOpen}
         setNavOpen={setNavOpen}
@@ -56,11 +60,90 @@ const AppStyled = styled.div`
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  position: relative;
+  overflow-x: hidden;
+  isolation: isolate;
+
+  .ambient{
+    position: fixed;
+    border-radius: 50%;
+    filter: blur(80px);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .ambient-one{
+    width: 42vw;
+    height: 42vw;
+    max-width: 520px;
+    max-height: 520px;
+    top: -8%;
+    right: -6%;
+    background: var(--mesh-1);
+    animation: ${keyframes`
+      0%, 100% { transform: translate(0, 0) scale(1); }
+      50% { transform: translate(-3%, 4%) scale(1.05); }
+    `} 18s ease-in-out infinite;
+  }
+
+  .ambient-two{
+    width: 36vw;
+    height: 36vw;
+    max-width: 440px;
+    max-height: 440px;
+    bottom: 10%;
+    left: -8%;
+    background: var(--mesh-2);
+    animation: ${keyframes`
+      0%, 100% { transform: translate(0, 0); }
+      50% { transform: translate(4%, -3%); }
+    `} 22s ease-in-out infinite;
+  }
+
+  .ambient-three{
+    width: 28vw;
+    height: 28vw;
+    max-width: 320px;
+    max-height: 320px;
+    top: 42%;
+    left: 38%;
+    background: var(--mesh-3);
+    animation: ${keyframes`
+      0%, 100% { transform: translate(0, 0); }
+      50% { transform: translate(-2%, 2%); }
+    `} 26s ease-in-out infinite;
+  }
+
+  .grid-overlay{
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    opacity: 0.35;
+    background-image:
+      linear-gradient(var(--border-color) 1px, transparent 1px),
+      linear-gradient(90deg, var(--border-color) 1px, transparent 1px);
+    background-size: 72px 72px;
+    mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 20%, transparent 70%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ambient {
+      animation: none;
+    }
+  }
 `;
 
 const MainContentStyled = styled.main`
   flex: 1;
-  padding-top: 4.25rem;
+  padding-top: 6.5rem;
+  position: relative;
+  z-index: 1;
+  animation: pageFadeIn 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 `;
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,13 +10,27 @@ import DemoPage from './Pages/DemoPage';
 import ContactPage from './Pages/ContactPage';
 import { Routes, Route } from 'react-router-dom';
 
+const THEME_STORAGE_KEY = 'portfolio-theme';
+
+function getInitialTheme() {
+  const saved = localStorage.getItem(THEME_STORAGE_KEY);
+  if (saved === 'light-theme' || saved === 'dark-theme') {
+    return saved;
+  }
+  return 'dark-theme';
+}
+
 function App() {
-  const [theme, setTheme] = useState('light-theme');
-  const [checked, setChecked] = useState(false);
+  const [theme, setTheme] = useState(getInitialTheme);
+  const [checked, setChecked] = useState(() => getInitialTheme() === 'dark-theme');
   const [navOpen, setNavOpen] = useState(false);
 
   useEffect(() => {
     document.documentElement.className = theme;
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute('content', theme === 'dark-theme' ? '#09090b' : '#f7f6f3');
   }, [theme]);
 
   const themeToggler = () => {

--- a/src/Components/DashboardPreview.jsx
+++ b/src/Components/DashboardPreview.jsx
@@ -93,11 +93,12 @@ function DashboardPreview() {
 
 const DashboardPreviewStyled = styled.div`
     width: 100%;
-    border: 1px solid var(--border-color);
-    border-radius: .85rem;
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-xl);
     overflow: hidden;
-    background: var(--surface-color);
-    box-shadow: var(--shadow-lg);
+    background: var(--glass-bg);
+    backdrop-filter: blur(20px);
+    box-shadow: var(--shadow-lg), var(--shadow-glow);
     animation: ${gentleFloat} 5s ease-in-out infinite;
 
     @media (prefers-reduced-motion: reduce) {
@@ -128,10 +129,10 @@ const DashboardPreviewStyled = styled.div`
             flex: 1;
             font-size: .75rem;
             color: var(--text-muted);
-            background: var(--surface-color);
+            background: var(--surface-solid);
             border: 1px solid var(--border-color);
-            border-radius: .35rem;
-            padding: .25rem .55rem;
+            border-radius: var(--radius-pill);
+            padding: .3rem .75rem;
         }
     }
 
@@ -159,9 +160,9 @@ const DashboardPreviewStyled = styled.div`
 
     .stat-card{
         border: 1px solid var(--border-color);
-        border-radius: .55rem;
+        border-radius: var(--radius-md);
         padding: .65rem .7rem;
-        background: var(--surface-muted);
+        background: var(--surface-solid);
         opacity: 0;
         animation: ${fadeUp} 0.55s ease forwards;
         animation-delay: var(--delay);

--- a/src/Components/DemoShowcase.jsx
+++ b/src/Components/DemoShowcase.jsx
@@ -26,9 +26,10 @@ const DemoShowcase = ({ compact = false, embedded = false }) => {
                 <p className="eyebrow">Example build</p>
                 <h3>{DEMO_DASHBOARD_NAME}</h3>
                 <p className="summary">
-                    A sample multi-location retail operation that could not quickly see
-                    stock levels, reorder needs, or transfer approvals. One dashboard.
-                    Clear alerts. Decisions in minutes instead of spreadsheet marathons.
+                    Built for a multi-location retailer that was checking stock, reorders,
+                    and transfer approvals across spreadsheets and email. This dashboard
+                    puts it in one place with clear alerts, so decisions take minutes
+                    instead of a spreadsheet marathon.
                 </p>
                 {!compact && (
                     <ul className="highlights">

--- a/src/Components/DemoShowcase.jsx
+++ b/src/Components/DemoShowcase.jsx
@@ -67,10 +67,10 @@ const DemoShowcase = ({ compact = false, embedded = false }) => {
 
 const DemoShowcaseStyled = styled.section`
     margin-top: 3rem;
-    background-color: var(--surface-color);
-    border: 1px solid var(--border-color);
-    border-left: 4px solid var(--primary-color);
-    border-radius: .75rem;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-xl);
+    backdrop-filter: blur(16px);
     box-shadow: var(--shadow-lg);
 
     .demo-content{
@@ -87,8 +87,10 @@ const DemoShowcaseStyled = styled.section`
     }
 
     h3{
+        font-family: 'Syne', sans-serif;
         color: var(--heading-color);
         font-size: 1.6rem;
+        letter-spacing: -0.03em;
         margin-bottom: .75rem;
     }
 
@@ -162,10 +164,10 @@ const DemoShowcaseStyled = styled.section`
         margin-top: 1.25rem;
         margin-bottom: 0;
         border: 1px solid var(--border-color);
-        border-left: 1px solid var(--border-color);
-        border-radius: .65rem;
-        background-color: var(--surface-muted);
+        border-radius: var(--radius-lg);
+        background: var(--surface-muted);
         box-shadow: none;
+        backdrop-filter: none;
 
         .demo-content{
             padding: 1.15rem 1.25rem;

--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -17,6 +17,7 @@ function Footer() {
                     <NavLink to="/services">Services</NavLink>
                     <NavLink to="/demo">Example</NavLink>
                     <NavLink to="/contact">Contact</NavLink>
+                    <NavLink to="/privacy">Privacy</NavLink>
                 </div>
             </div>
         </FooterStyled>

--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -6,7 +6,13 @@ function Footer() {
     return (
         <FooterStyled>
             <div className="footer-inner">
-                <p>© 2026 Gargi Thakur · Vancouver, BC</p>
+                <div className="footer-brand">
+                    <span className="mark">GT</span>
+                    <div>
+                        <p className="name">Gargi Thakur</p>
+                        <p className="meta">© 2026 · Vancouver, BC</p>
+                    </div>
+                </div>
                 <div className="footer-links">
                     <NavLink to="/services">Services</NavLink>
                     <NavLink to="/demo">Example</NavLink>
@@ -18,33 +24,66 @@ function Footer() {
 }
 
 const FooterStyled = styled.footer`
-    border-top: 1px solid var(--border-color);
-    background-color: var(--surface-color);
+    position: relative;
+    z-index: 1;
     margin-top: auto;
+    padding: 0 1.5rem 2rem;
 
     .footer-inner{
-        max-width: 72rem;
+        max-width: 80rem;
         margin: 0 auto;
-        padding: 1.5rem;
+        padding: 1.35rem 1.5rem;
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 1rem;
+        gap: 1.5rem;
         flex-wrap: wrap;
-        p{
-            font-size: .9rem;
+        border-radius: var(--radius-xl);
+        background: var(--glass-bg);
+        border: 1px solid var(--glass-border);
+        backdrop-filter: blur(16px);
+        box-shadow: var(--shadow-lg);
+    }
+
+    .footer-brand{
+        display: flex;
+        align-items: center;
+        gap: .85rem;
+        .mark{
+            width: 2.2rem;
+            height: 2.2rem;
+            border-radius: 50%;
+            background: var(--gradient-primary);
+            color: #fff;
+            font-family: 'Syne', sans-serif;
+            font-size: .68rem;
+            font-weight: 800;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .name{
+            font-family: 'Syne', sans-serif;
+            font-size: .95rem;
+            font-weight: 700;
+            color: var(--heading-color);
+        }
+        .meta{
+            font-size: .82rem;
             color: var(--text-muted);
         }
-        .footer-links{
-            display: flex;
-            gap: 1rem;
-            a{
-                font-size: .9rem;
-                color: var(--text-muted);
-                font-weight: 600;
-                &:hover{
-                    color: var(--primary-color);
-                }
+    }
+
+    .footer-links{
+        display: flex;
+        gap: 1.25rem;
+        a{
+            font-size: .88rem;
+            color: var(--text-muted);
+            font-weight: 600;
+            transition: color .2s ease;
+            &:hover{
+                color: var(--heading-color);
             }
         }
     }

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
 import MenuIcon from '@mui/icons-material/Menu';
 import CloseIcon from '@mui/icons-material/Close';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
+import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
+import LightModeOutlinedIcon from '@mui/icons-material/LightModeOutlined';
 import IconButton from '@mui/material/IconButton';
-import Switch from '@mui/material/Switch';
 
 const navItems = [
     { to: '/', label: 'Home', end: true },
@@ -16,15 +16,20 @@ const navItems = [
 ];
 
 function Header({ navOpen, setNavOpen, theme, onThemeToggle, themeChecked }) {
+    const isDark = theme === 'dark-theme';
+
     return (
         <HeaderStyled>
-            <div className="header-inner">
+            <div className="header-shell">
                 <NavLink to="/" className="brand" onClick={() => setNavOpen(false)} aria-label="Gargi Thakur home">
                     <span className="brand-mark" aria-hidden="true">GT</span>
-                    <span className="brand-name">Gargi Thakur</span>
+                    <span className="brand-copy">
+                        <span className="brand-name">Gargi Thakur</span>
+                        <span className="brand-tag">Operations & Automation</span>
+                    </span>
                 </NavLink>
 
-                <nav className={`nav-links ${navOpen ? 'open' : ''}`}>
+                <nav className={`nav-links ${navOpen ? 'open' : ''}`} aria-label="Main">
                     {navItems.map(({ to, label, end }) => (
                         <NavLink
                             key={to}
@@ -36,29 +41,19 @@ function Header({ navOpen, setNavOpen, theme, onThemeToggle, themeChecked }) {
                             {label}
                         </NavLink>
                     ))}
-                    <div className="mobile-theme">
-                        <Brightness4Icon />
-                        <Switch
-                            checked={themeChecked}
-                            onChange={onThemeToggle}
-                            inputProps={{ 'aria-label': 'Toggle dark mode' }}
-                            size="small"
-                        />
-                    </div>
                 </nav>
 
                 <div className="header-actions">
-                    <div className="desktop-theme">
-                        <Brightness4Icon />
-                        <Switch
-                            checked={themeChecked}
-                            onChange={onThemeToggle}
-                            inputProps={{ 'aria-label': 'Toggle dark mode' }}
-                            size="small"
-                        />
-                    </div>
+                    <button
+                        type="button"
+                        className="theme-toggle"
+                        onClick={onThemeToggle}
+                        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+                    >
+                        {isDark ? <LightModeOutlinedIcon /> : <DarkModeOutlinedIcon />}
+                    </button>
                     <NavLink to="/contact" className="header-cta" onClick={() => setNavOpen(false)}>
-                        Book workflow audit
+                        Book audit
                     </NavLink>
                     <IconButton
                         className="menu-toggle"
@@ -76,49 +71,71 @@ function Header({ navOpen, setNavOpen, theme, onThemeToggle, themeChecked }) {
 
 const HeaderStyled = styled.header`
     position: fixed;
-    top: 0;
+    top: 1rem;
     left: 0;
     right: 0;
     z-index: 100;
-    background-color: var(--surface-color);
-    border-bottom: 1px solid var(--border-color);
-    backdrop-filter: blur(10px);
+    padding: 0 1.25rem;
+    pointer-events: none;
 
-    .header-inner{
-        max-width: 72rem;
+    .header-shell{
+        pointer-events: auto;
+        max-width: 80rem;
         margin: 0 auto;
-        padding: 0 1.5rem;
-        height: 4.25rem;
+        padding: .55rem .65rem .55rem .85rem;
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 1rem;
+        border-radius: var(--radius-pill);
+        background: var(--glass-bg);
+        border: 1px solid var(--glass-border);
+        backdrop-filter: blur(20px) saturate(160%);
+        -webkit-backdrop-filter: blur(20px) saturate(160%);
+        box-shadow: var(--shadow-lg);
     }
 
     .brand{
         display: flex;
         align-items: center;
-        gap: .65rem;
+        gap: .75rem;
         min-width: 0;
         .brand-mark{
-            width: 2.1rem;
-            height: 2.1rem;
-            border-radius: .55rem;
-            background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+            width: 2.35rem;
+            height: 2.35rem;
+            border-radius: 50%;
+            background: var(--gradient-primary);
             color: #fff;
-            font-size: .78rem;
+            font-family: 'Syne', sans-serif;
+            font-size: .72rem;
             font-weight: 800;
-            letter-spacing: .04em;
+            letter-spacing: .06em;
             display: inline-flex;
             align-items: center;
             justify-content: center;
             flex-shrink: 0;
+            box-shadow: 0 8px 24px rgba(99, 102, 241, 0.35);
+        }
+        .brand-copy{
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
         }
         .brand-name{
             color: var(--heading-color);
-            font-size: 1.02rem;
+            font-family: 'Syne', sans-serif;
+            font-size: .95rem;
             font-weight: 700;
             letter-spacing: -0.02em;
+            line-height: 1.15;
+            white-space: nowrap;
+        }
+        .brand-tag{
+            color: var(--text-muted);
+            font-size: .68rem;
+            font-weight: 600;
+            letter-spacing: .04em;
+            text-transform: uppercase;
             white-space: nowrap;
         }
     }
@@ -126,49 +143,67 @@ const HeaderStyled = styled.header`
     .nav-links{
         display: flex;
         align-items: center;
-        gap: .25rem;
+        gap: .15rem;
+        padding: .2rem;
+        border-radius: var(--radius-pill);
+        background: var(--surface-muted);
+        border: 1px solid var(--border-color);
         a{
             color: var(--text-muted);
-            font-size: .92rem;
+            font-size: .82rem;
             font-weight: 600;
-            padding: .45rem .75rem;
-            border-radius: .4rem;
-            transition: color .2s ease, background-color .2s ease;
+            padding: .5rem .85rem;
+            border-radius: var(--radius-pill);
+            transition: color .25s ease, background-color .25s ease, transform .25s ease;
             &:hover{
                 color: var(--heading-color);
-                background-color: var(--surface-muted);
+                background-color: var(--surface-solid);
             }
             &.active{
-                color: var(--primary-color);
-                background-color: var(--primary-soft);
+                color: var(--heading-color);
+                background-color: var(--surface-solid);
+                box-shadow: 0 2px 12px rgba(10, 10, 11, 0.06);
             }
-        }
-        .mobile-theme{
-            display: none;
         }
     }
 
     .header-actions{
         display: flex;
         align-items: center;
-        gap: .5rem;
-        .desktop-theme{
-            display: flex;
+        gap: .45rem;
+        .theme-toggle{
+            display: inline-flex;
             align-items: center;
-            gap: .15rem;
+            justify-content: center;
+            width: 2.35rem;
+            height: 2.35rem;
+            border-radius: 50%;
+            border: 1px solid var(--border-color);
+            background: var(--surface-muted);
             color: var(--text-muted);
+            cursor: pointer;
+            transition: color .2s ease, border-color .2s ease, transform .2s ease;
+            svg{ font-size: 1.05rem; }
+            &:hover{
+                color: var(--heading-color);
+                border-color: var(--border-strong);
+                transform: rotate(-8deg);
+            }
         }
         .header-cta{
-            background-color: var(--primary-color);
+            background: var(--gradient-primary);
             color: #fff !important;
-            font-size: .85rem;
+            font-size: .82rem;
             font-weight: 700;
-            padding: .55rem 1rem;
-            border-radius: .45rem;
+            padding: .62rem 1.1rem;
+            border-radius: var(--radius-pill);
             white-space: nowrap;
-            transition: background-color .2s ease;
+            transition: transform .25s ease, box-shadow .25s ease, filter .25s ease;
+            box-shadow: 0 8px 24px rgba(99, 102, 241, 0.28);
             &:hover{
-                background-color: var(--primary-hover);
+                transform: translateY(-1px);
+                filter: brightness(1.05);
+                box-shadow: 0 12px 28px rgba(99, 102, 241, 0.35);
             }
         }
         .menu-toggle{
@@ -181,41 +216,53 @@ const HeaderStyled = styled.header`
         display: none;
     }
 
-    @media screen and (max-width: 900px){
+    @media screen and (max-width: 960px){
+        .brand-tag{
+            display: none;
+        }
         .nav-links{
+            display: none;
+        }
+    }
+
+    @media screen and (max-width: 900px){
+        top: .75rem;
+        padding: 0 .85rem;
+
+        .header-shell{
+            padding: .55rem .65rem;
+        }
+
+        .nav-links{
+            display: flex;
             position: fixed;
-            top: 4.25rem;
-            left: 0;
-            right: 0;
+            top: 5.25rem;
+            left: 1rem;
+            right: 1rem;
             flex-direction: column;
             align-items: stretch;
-            padding: 1rem 1.5rem 1.5rem;
-            background-color: var(--surface-color);
-            border-bottom: 1px solid var(--border-color);
-            transform: translateY(-120%);
+            padding: .75rem;
+            border-radius: var(--radius-xl);
+            background: var(--glass-bg);
+            backdrop-filter: blur(20px);
+            border: 1px solid var(--glass-border);
+            box-shadow: var(--shadow-lg);
+            transform: translateY(-8px) scale(0.98);
             opacity: 0;
             pointer-events: none;
-            transition: transform .25s ease, opacity .25s ease;
+            transition: transform .28s ease, opacity .28s ease;
             &.open{
-                transform: translateY(0);
+                transform: translateY(0) scale(1);
                 opacity: 1;
                 pointer-events: auto;
             }
             a{
-                padding: .75rem .5rem;
-            }
-            .mobile-theme{
-                display: flex;
-                align-items: center;
-                gap: .25rem;
-                margin-top: .5rem;
-                padding-top: .75rem;
-                border-top: 1px solid var(--border-color);
-                color: var(--text-muted);
+                padding: .85rem 1rem;
+                border-radius: var(--radius-md);
             }
         }
         .header-actions{
-            .desktop-theme, .header-cta{
+            .header-cta{
                 display: none;
             }
             .menu-toggle{
@@ -225,8 +272,11 @@ const HeaderStyled = styled.header`
         .nav-backdrop{
             display: block;
             position: fixed;
-            inset: 4.25rem 0 0 0;
-            background: rgba(15, 23, 42, 0.35);
+            inset: 0;
+            background: rgba(10, 10, 11, 0.35);
+            backdrop-filter: blur(4px);
+            pointer-events: auto;
+            z-index: -1;
         }
     }
 `;

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -153,7 +153,7 @@ const HeaderStyled = styled.header`
         background: var(--surface-muted);
         border: 1px solid var(--border-color);
         a{
-            color: var(--text-muted);
+            color: var(--nav-link-color, var(--font-light-color));
             font-size: .82rem;
             font-weight: 600;
             padding: .5rem .85rem;
@@ -245,11 +245,12 @@ const HeaderStyled = styled.header`
             right: 1rem;
             flex-direction: column;
             align-items: stretch;
-            padding: .75rem;
+            gap: .25rem;
+            padding: .65rem;
             border-radius: var(--radius-xl);
-            background: var(--glass-bg);
-            backdrop-filter: blur(20px);
-            border: 1px solid var(--glass-border);
+            background: var(--surface-solid);
+            backdrop-filter: none;
+            border: 1px solid var(--border-strong);
             box-shadow: var(--shadow-lg);
             transform: translateY(-8px) scale(0.98);
             opacity: 0;
@@ -261,8 +262,23 @@ const HeaderStyled = styled.header`
                 pointer-events: auto;
             }
             a{
-                padding: .85rem 1rem;
+                padding: .9rem 1rem;
                 border-radius: var(--radius-md);
+                font-size: .95rem;
+                font-weight: 600;
+                color: var(--font-light-color);
+                background: transparent;
+                &:hover,
+                &:focus-visible{
+                    color: var(--heading-color);
+                    background: var(--surface-muted);
+                }
+                &.active{
+                    color: var(--heading-color);
+                    background: var(--primary-soft);
+                    box-shadow: none;
+                    font-weight: 700;
+                }
             }
         }
         .header-actions{

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -268,14 +268,31 @@ const HeaderStyled = styled.header`
                 font-weight: 600;
                 color: var(--font-light-color);
                 background: transparent;
-                &:hover,
+                border: 1px solid transparent;
+                transition: color .2s ease, background-color .2s ease, border-color .2s ease, transform .2s ease;
+                @media (hover: hover){
+                    &:hover:not(.active){
+                        color: var(--heading-color);
+                        background: var(--menu-item-hover);
+                        border-color: var(--border-color);
+                        transform: translateX(3px);
+                    }
+                }
                 &:focus-visible{
                     color: var(--heading-color);
-                    background: var(--surface-muted);
+                    background: var(--menu-item-hover);
+                    border-color: var(--primary-color);
+                    outline: none;
+                }
+                &:active:not(.active){
+                    color: var(--heading-color);
+                    background: var(--menu-item-active);
+                    transform: scale(0.99);
                 }
                 &.active{
                     color: var(--heading-color);
-                    background: var(--primary-soft);
+                    background: var(--menu-item-active);
+                    border-color: rgba(99, 102, 241, 0.25);
                     box-shadow: none;
                     font-weight: 700;
                 }

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -15,7 +15,7 @@ const navItems = [
     { to: '/contact', label: 'Contact' },
 ];
 
-function Header({ navOpen, setNavOpen, theme, onThemeToggle, themeChecked }) {
+function Header({ navOpen, setNavOpen, theme, onThemeToggle, themeChecked, themePreference = 'auto' }) {
     const isDark = theme === 'dark-theme';
 
     return (
@@ -48,7 +48,11 @@ function Header({ navOpen, setNavOpen, theme, onThemeToggle, themeChecked }) {
                         type="button"
                         className="theme-toggle"
                         onClick={onThemeToggle}
-                        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+                        aria-label={
+                            themePreference === 'auto'
+                                ? (isDark ? 'Switch to light mode (manual override)' : 'Switch to dark mode (manual override)')
+                                : (isDark ? 'Switch to light mode' : 'Switch to dark mode')
+                        }
                     >
                         {isDark ? <LightModeOutlinedIcon /> : <DarkModeOutlinedIcon />}
                     </button>

--- a/src/Components/InfoSection.jsx
+++ b/src/Components/InfoSection.jsx
@@ -57,11 +57,14 @@ const InfoSectionStyled = styled.div`
     .content {
         width: 100%;
         h4 {
-            font-size: 1.6rem;
+            font-family: 'Syne', sans-serif;
+            font-size: 1.75rem;
             color: var(--heading-color);
             font-weight: 700;
+            letter-spacing: -0.03em;
             span {
                 font-size: inherit;
+                font-family: inherit;
                 color: var(--primary-color);
             }
         }

--- a/src/Components/OutlineButton.jsx
+++ b/src/Components/OutlineButton.jsx
@@ -10,20 +10,25 @@ const OutlineButton = ({ title }) => {
 }
 
 const OutlineButtonStyled = styled.span`
-    border: 1px solid var(--border-color);
-    padding: .72rem 1.3rem;
+    border: 1px solid var(--border-strong);
+    padding: .82rem 1.45rem;
     color: var(--heading-color);
-    background: var(--surface-color);
+    background: var(--surface-solid);
     cursor: pointer;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     font-size: .9rem;
     font-weight: 700;
-    border-radius: .45rem;
-    transition: border-color .2s ease, color .2s ease, background-color .2s ease;
+    border-radius: var(--radius-pill);
+    backdrop-filter: blur(8px);
+    transition: border-color .25s ease, color .25s ease, background-color .25s ease, transform .25s ease, box-shadow .25s ease;
     &:hover{
-        border-color: var(--primary-color);
+        border-color: var(--accent-color);
         color: var(--primary-color);
         background-color: var(--primary-soft);
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-lg);
     }
 `;
 

--- a/src/Components/PrimaryButton.jsx
+++ b/src/Components/PrimaryButton.jsx
@@ -4,25 +4,43 @@ import styled from 'styled-components';
 const PrimaryButton = ({ title }) => {
     return (
         <PrimaryButtonStyled>
-            {title}
+            <span>{title}</span>
         </PrimaryButtonStyled>
     )
 }
 
 const PrimaryButtonStyled = styled.span`
-    background-color: var(--primary-color);
-    padding: .75rem 1.35rem;
+    background: var(--gradient-primary);
+    padding: .85rem 1.5rem;
     color: white;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: .5rem;
     font-size: .9rem;
     font-weight: 700;
-    border-radius: .45rem;
-    transition: background-color .2s ease, transform .2s ease;
+    border-radius: var(--radius-pill);
+    box-shadow: 0 10px 28px rgba(99, 102, 241, 0.28);
+    transition: transform .25s cubic-bezier(0.22, 1, 0.36, 1), box-shadow .25s ease, filter .25s ease;
+    position: relative;
+    overflow: hidden;
+
+    &::after{
+        content: '→';
+        opacity: 0;
+        transform: translateX(-6px);
+        transition: opacity .25s ease, transform .25s ease;
+    }
+
     &:hover{
-        background-color: var(--primary-hover);
+        transform: translateY(-2px);
+        filter: brightness(1.04);
+        box-shadow: 0 14px 36px rgba(99, 102, 241, 0.38);
+        &::after{
+            opacity: 1;
+            transform: translateX(0);
+        }
     }
 `;
 

--- a/src/Components/SkillCard.jsx
+++ b/src/Components/SkillCard.jsx
@@ -16,25 +16,29 @@ const SkillCard = ({ image, icon, title, paragraph }) => {
 
 const SkillCardStyled = styled.div`
     height: 100%;
-    background-color: var(--surface-color);
-    border: 1px solid var(--border-color);
-    border-radius: .75rem;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-xl);
+    backdrop-filter: blur(16px);
     box-shadow: var(--shadow-lg);
-    transition: border-color .2s ease, transform .2s ease;
+    transition: border-color .3s ease, transform .3s cubic-bezier(0.22, 1, 0.36, 1), box-shadow .3s ease;
     &:hover{
-        border-color: var(--primary-color);
-        transform: translateY(-2px);
+        border-color: var(--border-strong);
+        transform: translateY(-4px);
+        box-shadow: var(--shadow-lg), var(--shadow-glow);
     }
     .container{
         height: 100%;
-        padding: 1.35rem;
+        padding: 1.5rem;
         display: flex;
         flex-direction: column;
         h4{
+            font-family: 'Syne', sans-serif;
             color: var(--heading-color);
-            font-size: 1.2rem;
-            padding: .75rem 0 .5rem;
+            font-size: 1.15rem;
+            padding: 1rem 0 .5rem;
             font-weight: 700;
+            letter-spacing: -0.02em;
         }
 
         p{
@@ -42,23 +46,25 @@ const SkillCardStyled = styled.div`
             padding: .25rem 0 0;
             color: var(--text-muted);
             font-size: .95rem;
-            line-height: 1.55;
+            line-height: 1.65;
         }
 
         img {
             height: 85px;
             width: 200px;
             object-fit: contain;
-
-            
         }
 
         .card-icon {
-            height: 85px;
+            width: 3.25rem;
+            height: 3.25rem;
+            border-radius: 50%;
+            background: var(--primary-soft);
             display: flex;
             align-items: center;
+            justify-content: center;
             svg {
-                font-size: 3.5rem;
+                font-size: 1.65rem;
                 color: var(--primary-color);
             }
         }

--- a/src/Components/SubmitButton.jsx
+++ b/src/Components/SubmitButton.jsx
@@ -10,18 +10,23 @@ const SubmitButton = ({ title }) => {
 }
 
 const SubmitButtonStyled = styled.button`
-    background-color: var(--primary-color);
-    padding: .75rem 1.35rem;
+    background: var(--gradient-primary);
+    padding: .85rem 1.5rem;
     color: white;
     cursor: pointer;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     font-size: .9rem;
     font-weight: 700;
-    border-radius: .45rem;
-    transition: background-color .2s ease;
+    border-radius: var(--radius-pill);
     border: none;
+    box-shadow: 0 10px 28px rgba(99, 102, 241, 0.28);
+    transition: transform .25s ease, box-shadow .25s ease, filter .25s ease;
     &:hover{
-        background-color: var(--primary-hover);
+        transform: translateY(-2px);
+        filter: brightness(1.04);
+        box-shadow: 0 14px 36px rgba(99, 102, 241, 0.38);
     }
 `;
 export default SubmitButton;

--- a/src/Components/Title.jsx
+++ b/src/Components/Title.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import styled from 'styled-components';
 
-const Title = ({ title, subtitle, as: Heading = 'h1' }) => {
+const Title = ({ title, subtitle, as: Heading = 'h1', label }) => {
     return (
         <TitleStyled>
+            {label && <p className="section-label">{label}</p>}
             <Heading>{title}</Heading>
             {subtitle && <p className="subtitle">{subtitle}</p>}
         </TitleStyled>
@@ -11,19 +12,39 @@ const Title = ({ title, subtitle, as: Heading = 'h1' }) => {
 }
 
 const TitleStyled = styled.div`
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
     h1, h2{
-        font-size: clamp(1.9rem, 3vw, 2.5rem);
+        font-family: 'Syne', sans-serif;
+        font-size: clamp(2.2rem, 4vw, 3.25rem);
         font-weight: 700;
-        letter-spacing: -0.02em;
-        margin-bottom: .5rem;
+        letter-spacing: -0.04em;
+        line-height: 1.05;
+        margin-bottom: .75rem;
         color: var(--heading-color);
+        max-width: 18ch;
+    }
+    .section-label{
+        display: inline-flex;
+        align-items: center;
+        gap: .5rem;
+        margin-bottom: 1rem;
+        color: var(--primary-color);
+        font-size: .72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: .14em;
+        &::before{
+            content: '';
+            width: 1.75rem;
+            height: 1px;
+            background: var(--gradient-primary);
+        }
     }
     .subtitle{
         max-width: 42rem;
         color: var(--text-muted);
-        font-size: 1.05rem;
-        line-height: 1.6;
+        font-size: 1.08rem;
+        line-height: 1.7;
     }
 `;
 

--- a/src/Pages/AboutPage.jsx
+++ b/src/Pages/AboutPage.jsx
@@ -17,6 +17,7 @@ const AboutPage = () => {
             <AboutStyled >
                 <Title
                     title={'About'}
+                    label={'Profile'}
                     subtitle={'Full-stack Software Developer in Vancouver, BC. I build operations dashboards and workflow automation so your team spends less time in spreadsheets and manual follow-ups.'}
                 />
                 <InfoSection />

--- a/src/Pages/ContactPage.jsx
+++ b/src/Pages/ContactPage.jsx
@@ -15,6 +15,7 @@ const ContactPage = () => {
         <MainLayout>
             <Title
                 title={'Contact'}
+                label={'Start here'}
                 subtitle={'Book a workflow audit or tell me what you want to see on one screen. I will reply with an honest next step.'}
             />
             <ContactPageStyled >
@@ -120,7 +121,7 @@ const ContactPageStyled = styled.section`
                 }
                 input{
                     border: 1px solid var(--border-color);
-                    border-radius: .45rem;
+                    border-radius: var(--radius-md);
                     outline: none;
                     background: var(--surface-color);
                     height: 50px;
@@ -129,9 +130,9 @@ const ContactPageStyled = styled.section`
                     color: inherit;
                 }
                 textarea{
-                    background-color: var(--surface-color);
+                    background-color: var(--surface-solid);
                     border: 1px solid var(--border-color);
-                    border-radius: .45rem;
+                    border-radius: var(--radius-md);
                     outline: none;
                     color: inherit;
                     width: 100%;

--- a/src/Pages/ContactPage.jsx
+++ b/src/Pages/ContactPage.jsx
@@ -75,9 +75,12 @@ const ContactPageStyled = styled.section`
         }
         .contact-title{
             h4{
+                font-family: 'Syne', sans-serif;
                 color: var(--heading-color);
                 padding: 1rem 0 .5rem;
                 font-size: 1.35rem;
+                font-weight: 700;
+                letter-spacing: -0.02em;
             }
             p{
                 color: var(--text-muted);
@@ -115,28 +118,45 @@ const ContactPageStyled = styled.section`
                     left: 20px;
                     top: -19px;
                     display: inline-block;
-                    background-color: var(--surface-color);
-                    padding:0 .5rem;
-                    color: inherit;
+                    background-color: var(--surface-solid);
+                    padding: 0 .5rem;
+                    font-size: .85rem;
+                    font-weight: 600;
+                    color: var(--heading-color);
                 }
                 input{
-                    border: 1px solid var(--border-color);
+                    border: 1px solid var(--border-strong);
                     border-radius: var(--radius-md);
                     outline: none;
-                    background: var(--surface-color);
+                    background: var(--surface-solid);
                     height: 50px;
-                    padding:0 15px;
+                    padding: 0 15px;
                     width: 100%;
-                    color: inherit;
+                    font-size: 1rem;
+                    line-height: 1.5;
+                    transition: border-color .2s ease, box-shadow .2s ease;
+                    &:focus{
+                        border-color: var(--primary-color);
+                        box-shadow: 0 0 0 3px var(--primary-soft);
+                    }
                 }
                 textarea{
                     background-color: var(--surface-solid);
-                    border: 1px solid var(--border-color);
+                    border: 1px solid var(--border-strong);
                     border-radius: var(--radius-md);
                     outline: none;
-                    color: inherit;
+                    color: var(--font-light-color);
                     width: 100%;
-                    padding: .8rem 1rem;
+                    min-height: 10rem;
+                    padding: .85rem 1rem;
+                    font-size: 1rem;
+                    line-height: 1.6;
+                    resize: vertical;
+                    transition: border-color .2s ease, box-shadow .2s ease;
+                    &:focus{
+                        border-color: var(--primary-color);
+                        box-shadow: 0 0 0 3px var(--primary-soft);
+                    }
                 }
             }
 

--- a/src/Pages/DemoPage.jsx
+++ b/src/Pages/DemoPage.jsx
@@ -50,6 +50,7 @@ const DemoPage = () => {
         <MainLayout>
             <Title
                 title={DEMO_DASHBOARD_NAME}
+                label={'Case study'}
                 subtitle={'Sample multi-location retail business. This is the kind of operations dashboard I build when stock visibility, reorders, and transfer approvals need to live in one place.'}
             />
             <DemoPageStyled>
@@ -245,13 +246,16 @@ const DemoPageStyled = styled.section`
     .closing-cta{
         margin-top: 3rem;
         padding: 2rem;
-        border: 1px solid var(--primary-color);
-        border-left: 4px solid var(--primary-color);
-        border-radius: .85rem;
-        background: var(--surface-color);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-xl);
+        background: var(--glass-bg);
+        backdrop-filter: blur(16px);
+        box-shadow: var(--shadow-lg);
         h3{
+            font-family: 'Syne', sans-serif;
             color: var(--heading-color);
             font-size: 1.5rem;
+            letter-spacing: -0.03em;
             margin-bottom: .65rem;
         }
         p{

--- a/src/Pages/HomePage.jsx
+++ b/src/Pages/HomePage.jsx
@@ -8,6 +8,12 @@ import TextLink from '../Components/TextLink';
 import DashboardPreview from '../Components/DashboardPreview';
 import useDocumentMeta from '../hooks/useDocumentMeta';
 
+const proofPoints = [
+    { value: '3–5', label: 'Key metrics on one screen' },
+    { value: '60–90', label: 'Minute workflow audit' },
+    { value: '1', label: 'Dashboard, not ten tabs' },
+];
+
 function HomePage() {
     useDocumentMeta(
         'Gargi Thakur | Operations Dashboards & Workflow Automation for Small Businesses',
@@ -17,13 +23,17 @@ function HomePage() {
         <HomePageStyled>
             <section className="hero">
                 <div className="hero-copy">
-                    <p className="eyebrow">Vancouver, BC · Full-stack developer</p>
-                    <h1>Know what needs attention before it costs you sales or time</h1>
+                    <p className="eyebrow">
+                        <span className="dot" aria-hidden="true" />
+                        Vancouver, BC · Full-stack Software Developer
+                    </p>
+                    <h1>
+                        Know what needs <span className="gradient-text">attention</span> before it costs you sales or time
+                    </h1>
                     <p className="lead">
                         I build operations dashboards and workflow automation for small
                         businesses stuck in spreadsheets, email threads, and manual checks.
-                        Whether you run inventory across locations or just need one place
-                        to see the numbers that matter, I help you act faster and firefight less.
+                        One place to see what matters. Less firefighting.
                     </p>
                     <div className="cta">
                         <NavLink to="/contact">
@@ -32,6 +42,14 @@ function HomePage() {
                         <NavLink to="/demo">
                             <OutlineButton title={'See NovaFit Example'} />
                         </NavLink>
+                    </div>
+                    <div className="proof-row">
+                        {proofPoints.map((item) => (
+                            <div className="proof-item" key={item.label}>
+                                <strong>{item.value}</strong>
+                                <span>{item.label}</span>
+                            </div>
+                        ))}
                     </div>
                     <div className="secondary-links">
                         <NavLink to="/services"><TextLink title={'Starter offers'} /></NavLink>
@@ -42,8 +60,9 @@ function HomePage() {
                     </div>
                 </div>
                 <div className="hero-visual">
+                    <div className="visual-glow" aria-hidden="true" />
                     <DashboardPreview />
-                    <p className="visual-caption">NovaFit AI Inventory Hub: multi-location stock visibility in one view</p>
+                    <p className="visual-caption">NovaFit AI Inventory Hub · multi-location stock visibility</p>
                 </div>
             </section>
         </HomePageStyled>
@@ -51,44 +70,90 @@ function HomePage() {
 }
 
 const HomePageStyled = styled.div`
-    max-width: 72rem;
+    max-width: 80rem;
     margin: 0 auto;
-    padding: 2.5rem 1.5rem 3rem;
+    padding: 1rem 1.5rem 4rem;
     width: 100%;
 
     .hero{
         display: grid;
         grid-template-columns: 1.05fr .95fr;
-        gap: 2.5rem;
+        gap: 3.5rem;
         align-items: center;
+        min-height: calc(100vh - 10rem);
     }
 
     .eyebrow{
-        color: var(--primary-color);
-        font-size: .82rem;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: .08em;
-        margin-bottom: .85rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .55rem;
+        padding: .45rem .85rem .45rem .65rem;
+        margin-bottom: 1.25rem;
+        border-radius: var(--radius-pill);
+        border: 1px solid var(--border-color);
+        background: var(--surface-muted);
+        color: var(--text-muted);
+        font-size: .78rem;
+        font-weight: 600;
+        letter-spacing: .02em;
+        .dot{
+            width: .45rem;
+            height: .45rem;
+            border-radius: 50%;
+            background: var(--gradient-primary);
+            box-shadow: 0 0 12px rgba(99, 102, 241, 0.6);
+        }
     }
 
     .lead{
-        margin-top: 1rem;
-        max-width: 34rem;
-        font-size: 1.08rem;
-        line-height: 1.65;
+        margin-top: 1.35rem;
+        max-width: 36rem;
+        font-size: 1.12rem;
+        line-height: 1.75;
         color: var(--text-muted);
     }
 
     .cta{
-        margin-top: 1.75rem;
+        margin-top: 2rem;
         display: flex;
         flex-wrap: wrap;
         gap: .85rem;
     }
 
+    .proof-row{
+        margin-top: 2.5rem;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: .85rem;
+        max-width: 36rem;
+    }
+
+    .proof-item{
+        padding: 1rem .95rem;
+        border-radius: var(--radius-lg);
+        background: var(--glass-bg);
+        border: 1px solid var(--glass-border);
+        backdrop-filter: blur(12px);
+        strong{
+            display: block;
+            font-family: 'Syne', sans-serif;
+            font-size: 1.35rem;
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            color: var(--heading-color);
+            line-height: 1.1;
+        }
+        span{
+            display: block;
+            margin-top: .35rem;
+            font-size: .78rem;
+            line-height: 1.4;
+            color: var(--text-muted);
+        }
+    }
+
     .secondary-links{
-        margin-top: 1rem;
+        margin-top: 1.35rem;
         display: flex;
         align-items: center;
         gap: 1.25rem;
@@ -106,25 +171,44 @@ const HomePageStyled = styled.div`
     }
 
     .hero-visual{
+        position: relative;
+        .visual-glow{
+            position: absolute;
+            inset: 10% -5% -5%;
+            background: var(--shadow-glow);
+            filter: blur(40px);
+            z-index: 0;
+        }
+        > *:not(.visual-glow){
+            position: relative;
+            z-index: 1;
+        }
         .visual-caption{
-            margin-top: .75rem;
-            font-size: .82rem;
+            margin-top: 1rem;
+            font-size: .78rem;
             color: var(--text-muted);
             text-align: center;
+            letter-spacing: .02em;
         }
     }
 
     @media screen and (max-width: 960px){
         .hero{
             grid-template-columns: 1fr;
+            min-height: auto;
+            gap: 2.5rem;
         }
         .hero-visual{
             order: -1;
         }
+        .proof-row{
+            grid-template-columns: 1fr;
+            max-width: 100%;
+        }
     }
 
     @media screen and (max-width: 642px){
-        padding: 1.5rem 1rem 2.5rem;
+        padding: .5rem 1rem 3rem;
     }
 `;
 

--- a/src/Pages/PrivacyPage.jsx
+++ b/src/Pages/PrivacyPage.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import styled from 'styled-components';
+import { NavLink } from 'react-router-dom';
+import { MainLayout, InnerLayout } from '../styles/Layouts';
+import Title from '../Components/Title';
+import useDocumentMeta from '../hooks/useDocumentMeta';
+
+const sections = [
+    {
+        title: 'Who this applies to',
+        body: 'This policy describes how Gargi Thakur ("I", "me") handles information on gargithakur.com. I am based in Vancouver, BC, Canada.',
+    },
+    {
+        title: 'What I collect',
+        body: 'If you use the contact form, I collect the name, email address, subject, and message you submit. I do not ask for payment details on this website.',
+    },
+    {
+        title: 'Why I collect it',
+        body: 'I use contact form information to respond to inquiries, scope projects, and follow up about services such as workflow audits or operations dashboard work.',
+    },
+    {
+        title: 'Where your data goes',
+        body: 'Contact form submissions are sent to a Google Form linked to my Google Workspace account. The site itself is hosted on Netlify. Netlify may process standard server logs (such as IP address, browser type, and pages visited) for security and performance.',
+    },
+    {
+        title: 'Local storage',
+        body: 'This site saves your theme preference (light or dark mode) in your browser local storage so the site remembers your choice. That data stays on your device unless you clear it.',
+    },
+    {
+        title: 'Analytics and cookies',
+        body: 'This site does not currently use analytics tools such as Google Analytics or advertising pixels. If that changes, this page will be updated.',
+    },
+    {
+        title: 'How long I keep information',
+        body: 'I keep contact form messages for as long as needed to respond and manage a business relationship, then delete or archive them when they are no longer needed.',
+    },
+    {
+        title: 'Your choices',
+        body: 'You can ask what information I have about you, request correction, or ask me to delete contact messages you sent. To make a request, use the contact page.',
+    },
+    {
+        title: 'Links to other sites',
+        body: 'This site links to external pages such as LinkedIn, the NovaFit demo, and Google Form processing. Those sites have their own privacy practices.',
+    },
+];
+
+const PrivacyPage = () => {
+    useDocumentMeta(
+        'Privacy Policy | Gargi Thakur',
+        'How gargithakur.com handles contact form data, hosting, and local theme preferences. Based in Vancouver, BC.'
+    );
+
+    return (
+        <MainLayout>
+            <Title
+                title={'Privacy Policy'}
+                label={'Legal'}
+                subtitle={'Plain-language summary of what this site collects and how it is used.'}
+            />
+            <PrivacyPageStyled>
+                <InnerLayout>
+                    <p className="updated">Last updated: June 2026</p>
+                    {sections.map((section) => (
+                        <section className="policy-block" key={section.title}>
+                            <h2>{section.title}</h2>
+                            <p>{section.body}</p>
+                        </section>
+                    ))}
+                    <p className="contact-note">
+                        Questions about privacy?{' '}
+                        <NavLink to="/contact">Contact me</NavLink>.
+                    </p>
+                </InnerLayout>
+            </PrivacyPageStyled>
+        </MainLayout>
+    );
+};
+
+const PrivacyPageStyled = styled.section`
+    .updated{
+        font-size: .9rem;
+        color: var(--text-muted);
+        margin-bottom: 2rem;
+    }
+
+    .policy-block{
+        margin-bottom: 1.75rem;
+        padding-bottom: 1.75rem;
+        border-bottom: 1px solid var(--border-color);
+
+        &:last-of-type{
+            border-bottom: none;
+        }
+
+        h2{
+            font-family: 'Syne', sans-serif;
+            font-size: 1.15rem;
+            font-weight: 700;
+            letter-spacing: -0.02em;
+            color: var(--heading-color);
+            margin-bottom: .5rem;
+        }
+
+        p{
+            max-width: 42rem;
+            line-height: 1.7;
+            color: var(--text-muted);
+        }
+    }
+
+    .contact-note{
+        margin-top: 1rem;
+        font-size: .95rem;
+        color: var(--text-muted);
+
+        a{
+            color: var(--primary-color);
+            font-weight: 600;
+            &:hover{
+                text-decoration: underline;
+            }
+        }
+    }
+`;
+
+export default PrivacyPage;

--- a/src/Pages/ServicesPage.jsx
+++ b/src/Pages/ServicesPage.jsx
@@ -21,6 +21,7 @@ const ServicesPage = () => {
         <MainLayout>
             <Title
                 title={'Services'}
+                label={'Offers'}
                 subtitle={'Three focused starter offers. Pick the one that matches where you are today.'}
             />
             <ServicesPageStyled>
@@ -165,13 +166,14 @@ const ServicesPage = () => {
 const ServicesPageStyled = styled.section`
     .path-guide{
         max-width: 46rem;
-        padding: 1rem 1.15rem;
-        margin-bottom: 1rem;
-        border: 1px solid var(--border-color);
-        border-radius: .75rem;
-        background: var(--surface-muted);
+        padding: 1.15rem 1.25rem;
+        margin-bottom: 1.25rem;
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-xl);
+        background: var(--glass-bg);
+        backdrop-filter: blur(12px);
         p{
-            line-height: 1.6;
+            line-height: 1.65;
             color: var(--text-muted);
             & + p{
                 margin-top: .5rem;
@@ -184,47 +186,56 @@ const ServicesPageStyled = styled.section`
 
     .intro{
         max-width: 46rem;
-        padding-bottom: .5rem;
-        line-height: 1.65;
+        padding-bottom: .75rem;
+        line-height: 1.7;
         color: var(--text-muted);
+        font-size: 1.05rem;
     }
 
     .service-card{
         position: relative;
-        background-color: var(--surface-color);
-        border: 1px solid var(--border-color);
-        border-radius: .85rem;
+        background: var(--glass-bg);
+        border: 1px solid var(--glass-border);
+        border-radius: var(--radius-xl);
         padding: 2rem;
         padding-top: 2.25rem;
-        margin-top: 2rem;
+        margin-top: 1.75rem;
+        backdrop-filter: blur(16px);
         box-shadow: var(--shadow-lg);
-        transition: border-color .2s ease, transform .2s ease;
+        transition: border-color .3s ease, transform .3s cubic-bezier(0.22, 1, 0.36, 1), box-shadow .3s ease;
+        overflow: hidden;
         &:hover{
-            border-color: var(--primary-color);
-            transform: translateY(-2px);
+            border-color: var(--border-strong);
+            transform: translateY(-4px);
+            box-shadow: var(--shadow-lg), var(--shadow-glow);
         }
         &.featured{
-            border-color: var(--primary-color);
-            border-left: 4px solid var(--primary-color);
-        }
-        &.entry{
-            border-left: 4px solid var(--border-color);
+            border-color: rgba(99, 102, 241, 0.35);
+            &::before{
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                height: 3px;
+                background: var(--gradient-primary);
+            }
         }
 
         .badge{
             position: absolute;
-            top: 1.2rem;
-            right: 1.2rem;
-            background-color: var(--primary-soft);
+            top: 1.35rem;
+            right: 1.35rem;
+            background: var(--primary-soft);
             color: var(--primary-color);
-            font-size: .75rem;
+            font-size: .68rem;
             font-weight: 700;
             text-transform: uppercase;
-            letter-spacing: 1px;
-            padding: .3rem .75rem;
-            border-radius: 999px;
+            letter-spacing: .12em;
+            padding: .35rem .8rem;
+            border-radius: var(--radius-pill);
             &.entry-badge{
-                background-color: var(--surface-muted);
+                background: var(--surface-muted);
                 color: var(--heading-color);
             }
         }
@@ -237,22 +248,29 @@ const ServicesPageStyled = styled.section`
         margin-bottom: .25rem;
         padding-right: 6.5rem;
         h3{
+            font-family: 'Syne', sans-serif;
             color: var(--heading-color);
             font-size: 1.55rem;
+            letter-spacing: -0.03em;
             margin-bottom: .35rem;
         }
         .best-for{
             font-size: .92rem;
             color: var(--text-muted);
-            line-height: 1.5;
+            line-height: 1.55;
             max-width: 36rem;
         }
         .card-icon{
             display: flex;
             align-items: center;
+            justify-content: center;
+            width: 3.25rem;
+            height: 3.25rem;
+            border-radius: 50%;
+            background: var(--primary-soft);
             flex-shrink: 0;
             svg{
-                font-size: 2.8rem;
+                font-size: 1.65rem;
                 color: var(--primary-color);
             }
         }
@@ -282,8 +300,9 @@ const ServicesPageStyled = styled.section`
 
     .price-direction{
         margin-bottom: 0;
-        padding: .85rem 1rem;
-        border-left: 3px solid var(--primary-color);
+        padding: .9rem 1rem;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--border-color);
         background: var(--surface-muted);
         font-size: .92rem;
         line-height: 1.55;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -29,7 +29,8 @@ const GlobalStyle = createGlobalStyle`
     --heading-color: #0a0a0b;
     --white-color: #0a0a0b;
     --font-light-color: #3f3f46;
-    --text-muted: #71717a;
+    --text-muted: #52525b;
+    --nav-link-color: #27272a;
     --font-dark-color: #0a0a0b;
     --font-dark-color-2: #18181b;
     --sidebar-dark-color: #ffffff;
@@ -68,6 +69,7 @@ const GlobalStyle = createGlobalStyle`
     --white-color: #fafafa;
     --font-light-color: #d4d4d8;
     --text-muted: #a1a1aa;
+    --nav-link-color: #e4e4e7;
     --font-dark-color: #e4e4e7;
     --font-dark-color-2: #fafafa;
     --sidebar-dark-color: #18181b;
@@ -122,6 +124,20 @@ body::-webkit-scrollbar-track{
 
 textarea{
     max-width: 100%;
+}
+
+input,
+textarea,
+select,
+button{
+    font: inherit;
+    color: inherit;
+}
+
+input::placeholder,
+textarea::placeholder{
+    color: var(--text-muted);
+    opacity: 1;
 }
 
 a{

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,7 +1,16 @@
 import { createGlobalStyle } from 'styled-components';
 
+const sharedRadius = `
+    --radius-sm: 0.5rem;
+    --radius-md: 0.85rem;
+    --radius-lg: 1.25rem;
+    --radius-xl: 1.75rem;
+    --radius-pill: 999px;
+`;
+
 const GlobalStyle = createGlobalStyle`
 .light-theme{
+    ${sharedRadius}
     --primary-color: #4338ca;
     --primary-hover: #3730a3;
     --primary-soft: rgba(67, 56, 202, 0.1);
@@ -36,14 +45,10 @@ const GlobalStyle = createGlobalStyle`
     --scrollbar-bg-color: #e7e5e4;
     --scrollbar-thump-color: #a1a1aa;
     --scrollbar-track-color: #f4f4f5;
-    --radius-sm: 0.5rem;
-    --radius-md: 0.85rem;
-    --radius-lg: 1.25rem;
-    --radius-xl: 1.75rem;
-    --radius-pill: 999px;
 }
 
 .dark-theme{
+    ${sharedRadius}
     --primary-color: #818cf8;
     --primary-hover: #a5b4fc;
     --primary-soft: rgba(129, 140, 248, 0.14);

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -2,53 +2,82 @@ import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
 .light-theme{
-    --primary-color: #1d4ed8;
-    --primary-hover: #1e40af;
-    --primary-soft: rgba(29, 78, 216, 0.1);
-    --secondary-color: #e2e8f0;
-    --background-dark-color: #f8fafc;
+    --primary-color: #4338ca;
+    --primary-hover: #3730a3;
+    --primary-soft: rgba(67, 56, 202, 0.1);
+    --accent-color: #6366f1;
+    --accent-warm: #818cf8;
+    --secondary-color: #e7e5e4;
+    --background-dark-color: #f7f6f3;
     --background-dark-grey: #ffffff;
-    --surface-color: #ffffff;
-    --surface-muted: #f1f5f9;
-    --border-color: #e2e8f0;
-    --background-light-color: #f8fafc;
-    --background-light-color-2: rgba(29, 78, 216, 0.12);
-    --heading-color: #0f172a;
-    --white-color: #0f172a;
-    --font-light-color: #475569;
-    --text-muted: #64748b;
-    --font-dark-color: #0f172a;
-    --font-dark-color-2: #1e293b;
+    --surface-color: rgba(255, 255, 255, 0.72);
+    --surface-solid: #ffffff;
+    --surface-muted: rgba(255, 255, 255, 0.55);
+    --border-color: rgba(10, 10, 11, 0.08);
+    --border-strong: rgba(10, 10, 11, 0.14);
+    --background-light-color: #f7f6f3;
+    --background-light-color-2: rgba(67, 56, 202, 0.08);
+    --heading-color: #0a0a0b;
+    --white-color: #0a0a0b;
+    --font-light-color: #3f3f46;
+    --text-muted: #71717a;
+    --font-dark-color: #0a0a0b;
+    --font-dark-color-2: #18181b;
     --sidebar-dark-color: #ffffff;
-    --shadow-lg: 0 18px 40px rgba(15, 23, 42, 0.08);
-    --scrollbar-bg-color: #e2e8f0;
-    --scrollbar-thump-color: #94a3b8;
-    --scrollbar-track-color: #f1f5f9;
+    --shadow-lg: 0 24px 64px rgba(10, 10, 11, 0.08);
+    --shadow-glow: 0 0 80px rgba(99, 102, 241, 0.15);
+    --gradient-primary: linear-gradient(135deg, #4338ca 0%, #6366f1 50%, #818cf8 100%);
+    --gradient-text: linear-gradient(135deg, #4338ca 0%, #6366f1 60%, #a78bfa 100%);
+    --mesh-1: rgba(99, 102, 241, 0.18);
+    --mesh-2: rgba(167, 139, 250, 0.12);
+    --mesh-3: rgba(67, 56, 202, 0.08);
+    --glass-bg: rgba(255, 255, 255, 0.65);
+    --glass-border: rgba(255, 255, 255, 0.8);
+    --scrollbar-bg-color: #e7e5e4;
+    --scrollbar-thump-color: #a1a1aa;
+    --scrollbar-track-color: #f4f4f5;
+    --radius-sm: 0.5rem;
+    --radius-md: 0.85rem;
+    --radius-lg: 1.25rem;
+    --radius-xl: 1.75rem;
+    --radius-pill: 999px;
 }
 
 .dark-theme{
-    --primary-color: #60a5fa;
-    --primary-hover: #3b82f6;
-    --primary-soft: rgba(96, 165, 250, 0.14);
-    --secondary-color: #334155;
-    --background-dark-color: #0b1220;
-    --background-dark-grey: #111827;
-    --surface-color: #111827;
-    --surface-muted: #1f2937;
-    --border-color: #334155;
-    --background-light-color: #111827;
-    --background-light-color-2: rgba(96, 165, 250, 0.16);
-    --heading-color: #f8fafc;
-    --white-color: #f8fafc;
-    --font-light-color: #cbd5e1;
-    --text-muted: #94a3b8;
-    --font-dark-color: #e2e8f0;
-    --font-dark-color-2: #f8fafc;
-    --sidebar-dark-color: #111827;
-    --shadow-lg: 0 18px 40px rgba(0, 0, 0, 0.35);
-    --scrollbar-bg-color: #1f2937;
-    --scrollbar-thump-color: #64748b;
-    --scrollbar-track-color: #111827;
+    --primary-color: #818cf8;
+    --primary-hover: #a5b4fc;
+    --primary-soft: rgba(129, 140, 248, 0.14);
+    --accent-color: #6366f1;
+    --accent-warm: #a78bfa;
+    --secondary-color: #27272a;
+    --background-dark-color: #09090b;
+    --background-dark-grey: #111113;
+    --surface-color: rgba(24, 24, 27, 0.72);
+    --surface-solid: #18181b;
+    --surface-muted: rgba(39, 39, 42, 0.65);
+    --border-color: rgba(255, 255, 255, 0.08);
+    --border-strong: rgba(255, 255, 255, 0.14);
+    --background-light-color: #111113;
+    --background-light-color-2: rgba(129, 140, 248, 0.12);
+    --heading-color: #fafafa;
+    --white-color: #fafafa;
+    --font-light-color: #d4d4d8;
+    --text-muted: #a1a1aa;
+    --font-dark-color: #e4e4e7;
+    --font-dark-color-2: #fafafa;
+    --sidebar-dark-color: #18181b;
+    --shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.45);
+    --shadow-glow: 0 0 100px rgba(99, 102, 241, 0.2);
+    --gradient-primary: linear-gradient(135deg, #6366f1 0%, #818cf8 50%, #a78bfa 100%);
+    --gradient-text: linear-gradient(135deg, #818cf8 0%, #a78bfa 60%, #c4b5fd 100%);
+    --mesh-1: rgba(99, 102, 241, 0.22);
+    --mesh-2: rgba(167, 139, 250, 0.14);
+    --mesh-3: rgba(129, 140, 248, 0.08);
+    --glass-bg: rgba(24, 24, 27, 0.72);
+    --glass-border: rgba(255, 255, 255, 0.1);
+    --scrollbar-bg-color: #27272a;
+    --scrollbar-thump-color: #52525b;
+    --scrollbar-track-color: #18181b;
 }
 
 *{
@@ -57,18 +86,24 @@ const GlobalStyle = createGlobalStyle`
     box-sizing: border-box;
     list-style: none;
     text-decoration: none;
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+html{
+    scroll-behavior: smooth;
 }
 
 body{
+    font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
     background-color: var(--background-dark-color);
     color: var(--font-light-color);
-    transition: background-color .25s ease, color .25s ease;
+    transition: background-color .35s ease, color .35s ease;
     line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 body::-webkit-scrollbar{
-    width: 9px;
+    width: 8px;
     background-color: var(--scrollbar-track-color);
 }
 body::-webkit-scrollbar-thumb{
@@ -90,23 +125,30 @@ a{
     font-size: inherit;
 }
 
-h1{
-    font-size: clamp(2.2rem, 4vw, 3.4rem);
+h1, h2, h3, h4{
+    font-family: 'Syne', 'DM Sans', system-ui, sans-serif;
     color: var(--heading-color);
-    line-height: 1.15;
-    letter-spacing: -0.02em;
+}
+
+h1{
+    font-size: clamp(2.6rem, 5.5vw, 4.5rem);
+    line-height: 1.02;
+    letter-spacing: -0.04em;
+    font-weight: 700;
     span{
-        color: var(--primary-color);
         font-size: inherit;
+        font-family: inherit;
+    }
+    .gradient-text{
+        background: var(--gradient-text);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
     }
 }
 
 h2, h3, h4{
-    color: var(--heading-color);
-}
-
-span{
-    color: var(--primary-color);
+    letter-spacing: -0.03em;
 }
 
 h6{
@@ -121,6 +163,23 @@ p{
 
 .u-margin-bottom{
     margin-bottom: 4rem;
+}
+
+@keyframes pageFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
 }
 `;
 

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -43,6 +43,8 @@ const GlobalStyle = createGlobalStyle`
     --mesh-3: rgba(67, 56, 202, 0.08);
     --glass-bg: rgba(255, 255, 255, 0.65);
     --glass-border: rgba(255, 255, 255, 0.8);
+    --menu-item-hover: rgba(67, 56, 202, 0.08);
+    --menu-item-active: rgba(67, 56, 202, 0.14);
     --scrollbar-bg-color: #e7e5e4;
     --scrollbar-thump-color: #a1a1aa;
     --scrollbar-track-color: #f4f4f5;
@@ -82,6 +84,8 @@ const GlobalStyle = createGlobalStyle`
     --mesh-3: rgba(129, 140, 248, 0.08);
     --glass-bg: rgba(24, 24, 27, 0.72);
     --glass-border: rgba(255, 255, 255, 0.1);
+    --menu-item-hover: rgba(129, 140, 248, 0.12);
+    --menu-item-active: rgba(129, 140, 248, 0.2);
     --scrollbar-bg-color: #27272a;
     --scrollbar-thump-color: #52525b;
     --scrollbar-track-color: #18181b;

--- a/src/styles/Layouts.js
+++ b/src/styles/Layouts.js
@@ -1,16 +1,24 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 export const MainLayout = styled.div`
-    padding: 2rem 1.5rem 3rem;
-    max-width: 72rem;
+    padding: 1rem 1.5rem 4rem;
+    max-width: 80rem;
     margin: 0 auto;
     width: 100%;
 
     @media screen and (max-width: 642px){
-        padding: 1.5rem 1rem 2.5rem;
+        padding: .5rem 1rem 3rem;
     }
 `;
 
 export const InnerLayout = styled.div`
-    padding: 1rem 0 2rem;
+    padding: .5rem 0 1rem;
+`;
+
+export const GlassCard = styled.div`
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-xl);
+    backdrop-filter: blur(16px);
+    box-shadow: var(--shadow-lg);
 `;

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,98 @@
+const LIGHT_START_HOUR = 7;
+const DARK_START_HOUR = 19;
+
+export const THEME_MODE_KEY = 'portfolio-theme-mode';
+export const THEME_MANUAL_KEY = 'portfolio-theme-manual';
+/** @deprecated legacy single-key storage — migrated on read */
+export const THEME_STORAGE_KEY = 'portfolio-theme';
+
+export function getThemeForTimeOfDay(date = new Date()) {
+  const hour = date.getHours();
+  const isDaytime = hour >= LIGHT_START_HOUR && hour < DARK_START_HOUR;
+  return isDaytime ? 'light-theme' : 'dark-theme';
+}
+
+export function msUntilNextThemeChange(date = new Date()) {
+  const hour = date.getHours();
+  const next = new Date(date);
+
+  if (hour >= LIGHT_START_HOUR && hour < DARK_START_HOUR) {
+    next.setHours(DARK_START_HOUR, 0, 0, 0);
+  } else {
+    if (hour >= DARK_START_HOUR) {
+      next.setDate(next.getDate() + 1);
+    }
+    next.setHours(LIGHT_START_HOUR, 0, 0, 0);
+  }
+
+  return Math.max(next.getTime() - date.getTime(), 1000);
+}
+
+export function resolveTheme(mode, manualTheme, _tick = 0) {
+  if (mode === 'manual' && (manualTheme === 'light-theme' || manualTheme === 'dark-theme')) {
+    return manualTheme;
+  }
+  return getThemeForTimeOfDay();
+}
+
+function migrateLegacyThemeStorage() {
+  const existingMode = localStorage.getItem(THEME_MODE_KEY);
+  if (existingMode === 'auto' || existingMode === 'manual') {
+    return;
+  }
+
+  const legacy = localStorage.getItem(THEME_STORAGE_KEY);
+
+  // Legacy "dark-theme" default was written automatically for all visitors.
+  // Treat unknown legacy values as auto so time-of-day works out of the box.
+  if (legacy === 'light-theme' || legacy === 'dark-theme') {
+    localStorage.setItem(THEME_MODE_KEY, 'auto');
+    localStorage.removeItem(THEME_MANUAL_KEY);
+  } else if (legacy === 'auto') {
+    localStorage.setItem(THEME_MODE_KEY, 'auto');
+  } else {
+    localStorage.setItem(THEME_MODE_KEY, 'auto');
+  }
+
+  localStorage.removeItem(THEME_STORAGE_KEY);
+}
+
+export function getInitialThemeState() {
+  migrateLegacyThemeStorage();
+
+  const mode = localStorage.getItem(THEME_MODE_KEY);
+  const manualTheme = localStorage.getItem(THEME_MANUAL_KEY);
+
+  if (mode === 'manual' && (manualTheme === 'light-theme' || manualTheme === 'dark-theme')) {
+    return { mode: 'manual', manualTheme };
+  }
+
+  return { mode: 'auto', manualTheme: getThemeForTimeOfDay() };
+}
+
+export function persistThemeState(mode, manualTheme) {
+  localStorage.setItem(THEME_MODE_KEY, mode);
+  if (mode === 'manual') {
+    localStorage.setItem(THEME_MANUAL_KEY, manualTheme);
+  } else {
+    localStorage.removeItem(THEME_MANUAL_KEY);
+  }
+  localStorage.removeItem(THEME_STORAGE_KEY);
+}
+
+/** Used by index.html inline script before React loads */
+export function getThemeForInitialPaint() {
+  const mode = localStorage.getItem(THEME_MODE_KEY);
+  const manualTheme = localStorage.getItem(THEME_MANUAL_KEY);
+  const legacy = localStorage.getItem(THEME_STORAGE_KEY);
+
+  if (mode === 'manual' && (manualTheme === 'light-theme' || manualTheme === 'dark-theme')) {
+    return manualTheme;
+  }
+
+  if (mode === 'auto' || legacy === 'auto' || legacy === 'light-theme' || legacy === 'dark-theme') {
+    return getThemeForTimeOfDay();
+  }
+
+  return getThemeForTimeOfDay();
+}


### PR DESCRIPTION
- Refresh the visual system with Syne/DM Sans typography, glass surfaces, ambient gradients, and a floating pill navigation bar
- Improve conversion-focused pages with a stronger hero, packaged services layout, NovaFit case-study copy, and clearer CTAs
- Add time-of-day auto theming (light 7am–7pm, dark overnight) with manual override and legacy preference migration
- Add a plain-language /privacy page with footer link and sitemap entry
- Fix UI polish: dark-mode border radius tokens, mobile nav contrast/hover states, and contact form typography